### PR TITLE
BugFix: scaling next_state instead of reward

### DIFF
--- a/utils/buffer.py
+++ b/utils/buffer.py
@@ -42,7 +42,7 @@ class ReplayBuffer(object):
         
         # reward shaping, r = scale * r + shift, from CQL, FisherBRC, IQL, etc.
         # a common trick used for sparse reward env
-        transition[3] = self.scale * transition[3] + self.shift
+        transition[2] = self.scale * transition[2] + self.shift
         
         return transition
 


### PR DESCRIPTION
Hi. 

I've found a bug in your implementation of a buffer, where you take the third element of a `transition` list, which is `self.next_state[ind]` instead of taking the second element `self.reward[ind]`. I didn't conduct a full stack of multi-seed experiments, but in a one seed experiment the bugfix seems to work (while scaling the `next_state` obviously didn't work at all).

The run with scaling state: https://api.wandb.ai/links/tlab/730w1jxq
The run with scaling reward: https://api.wandb.ai/links/tlab/q9m21253